### PR TITLE
FL_KEYDOWN wasn't picking up keypresses

### DIFF
--- a/tetris.cpp
+++ b/tetris.cpp
@@ -451,8 +451,9 @@ class Board : public Fl_Widget
 
   int handle(int e)
   {
-    if(e == FL_KEYDOWN)
+    if(e == 12)
     {
+
       switch(Fl::event_key())
       {
         case FL_Escape: exit(1);


### PR DESCRIPTION
Ubuntu 18.04
GNOME 3.28.2

used following command to compile:
`fltk-config --compile tetris.cpp --use-forms --use-gl --use-images --ldstaticflags --cxxflags`

`fltk-config --version`
`1.3.5`



I'm not sure where the 12 came from, but by printing value of e out I found that e was 12 when any key was pressed so I guess it works haha